### PR TITLE
Tags meta, versión jQuery y comentarios

### DIFF
--- a/views/movie.ejs
+++ b/views/movie.ejs
@@ -3,6 +3,9 @@
 
 <head>
 	<meta charset="UTF-8">
+	<meta name="description" content="..." />
+   	<meta name="keywords" content="..." />
+    	<meta name="author" content="..." />
 	<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
 


### PR DESCRIPTION
Recuerden los tags meta que describen su página y son útiles para los buscadores. Por otro lado la versión de jQuery (2.1.1) está obsoleta, les recomiendo que la actualicen (https://code.jquery.com/jquery-3.4.1.min.js). Así mismo existe una versión slim que pesa menos que la minificada, removiéndole algunas funciones. Pueden probar y verificar si verdaderamente necesitan todas las funciones (minificado) o con slim es suficiente (lo cual sería más rápido): 
<script
			  src="https://code.jquery.com/jquery-3.4.1.slim.js"
			  integrity="sha256-BTlTdQO9/fascB1drekrDVkaKd9PkwBymMlHOiG+qLI="
			  crossorigin="anonymous"></script>

Por último, se nota el empeño en el trabajo y me pareció muy interesante como utilizan partials de EJS. Gran trabajo!